### PR TITLE
Update healthcheck log level to silly

### DIFF
--- a/app/routes/health.js
+++ b/app/routes/health.js
@@ -1,7 +1,7 @@
 const logger = require('../config/logger')(__filename);
 
 const health = (req, res) => {
-  logger.verbose('API is Alive & Kicking!');
+  logger.silly('API is Alive & Kicking!');
   return res.status(200).json({ 'status': 'UP' });
 };
 


### PR DESCRIPTION
This PR updates the healthcheck log level to silly so that we don't keep seeing the healthcheck messages unnecessarily.