### PR TITLE
COP-2488: Add service user using Hawk for sGMR API

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -148,6 +148,10 @@ pipeline:
         target: NGINX_IMAGE
       - source: NGINX_TAG
         target: NGINX_TAG
+      - source: DEV_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_ACCESS_KEY_ID
+      - source: DEV_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_SECRET_ACCESS_KEY
     commands:
       - export API_REF_TAG=$${DRONE_COMMIT_SHA}
       - export DB_REF_READ_ROLE="refreadonly"
@@ -208,6 +212,10 @@ pipeline:
         target: NGINX_IMAGE
       - source: NGINX_TAG
         target: NGINX_TAG
+      - source: STAGING_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_ACCESS_KEY_ID
+      - source: STAGING_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_SECRET_ACCESS_KEY
     commands:
       - export API_REF_TAG=$${DRONE_COMMIT_SHA}
       - export DB_REF_READ_ROLE="refreadonly"
@@ -268,6 +276,10 @@ pipeline:
         target: NGINX_IMAGE
       - source: NGINX_TAG
         target: NGINX_TAG
+      - source: PRODUCTION_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_ACCESS_KEY_ID
+      - source: PRODUCTION_HAWK_SGMR_ACCESS_KEY_ID
+        target: HAWK_SGMR_SECRET_ACCESS_KEY
     commands:
       - export API_REF_TAG=$${DRONE_COMMIT_SHA}
       - export DB_REF_READ_ROLE="refreadonly"

--- a/app/config/core.js
+++ b/app/config/core.js
@@ -32,13 +32,13 @@ const db = {
 const dbConnectionString = `${db.protocol}${db.username}:${db.password}@${db.hostname}:${db.port}/${db.dbname}${db.options}`;
 const keycloakClientPublicKey = process.env.API_REF_KEYCLOAK_CLIENT_PUBLIC_KEY || 'dummykey';
 const decodedKey = Buffer.from(keycloakClientPublicKey, 'base64').toString();
-
+const dbRead = process.env.DB_REF_READ_ROLE || 'refreadonly';
 
 const config = {
   camundaUrls,
   dbConnectionString,
   dbSchema: process.env.DB_REF_REFERENCE_SCHEMA || 'reference',
-  dbRead: process.env.DB_REF_READ_ROLE || 'refreadonly',
+  dbRead,
   dbWrite: process.env.DB_REF_WRITE_ROLE || 'refservice',
   iss: `${keycloak.protocol}${keycloak.url}/realms/${keycloak.realm}`,
   keycloakClientId: process.env.API_REF_KEYCLOAK_CLIENT_ID || 'api-ref',
@@ -46,6 +46,15 @@ const config = {
   limitRows: process.env.LIMIT_ROWS || false,
   logLevel: process.env.API_REF_LOG_LEVEL || 'info',
   port: process.env.API_REF_PORT || '5000',
+  hawkCredentials: [
+    {
+      user: 'sGMR Data API',
+      id: process.env.HAWK_SGMR_ACCESS_KEY_ID,
+      key: process.env.HAWK_SGMR_SECRET_ACCESS_KEY,
+      algorithm: 'sha256',
+      role: dbRead,
+    },
+  ],
 };
 
 module.exports = config;

--- a/app/routes/middlewares/auth.js
+++ b/app/routes/middlewares/auth.js
@@ -1,42 +1,39 @@
 const jwt = require('jsonwebtoken');
 const moment = require('moment');
+const Hawk = require('@hapi/hawk');
 
 const config = require('../../config/core');
 const logger = require('../../config/logger')(__filename);
 
 const BEARER = 'Bearer ';
+const HAWK = 'Hawk ';
 const ONE_SECOND = 1000;
 
-const authMiddleware = (req, res, next) => {
+const jwtAuthMiddleware = (req, res, next) => {
   const certificate = config.keycloakClientPublicKey;
-
   if (req.headers.authorization) {
     const currentTimestamp = Math.floor(Date.now() / ONE_SECOND);
-    let encodedToken = req.headers.authorization;
-
-    if (encodedToken.startsWith(BEARER)) {
-      encodedToken = encodedToken.slice(
-        BEARER.length,
-        req.headers.authorization.length,
-      );
-    }
+    let encodedToken = req.headers.authorization.slice(
+      BEARER.length,
+      req.headers.authorization.length,
+    );
 
     try {
-      const token = jwt.verify(encodedToken, certificate, {
+      const user = jwt.verify(encodedToken, certificate, {
         audience: config.keycloakClientId, // check the token audience matches keycloak
         issuer: config.iss, // check the issuer matches config
         ignoreExpiration: false, // check the expiry
         clockTimestamp: currentTimestamp, // set the time to base measurements from
       });
 
-      const tokenExpiry = moment(token.exp * ONE_SECOND);
+      const tokenExpiry = moment(user.exp * ONE_SECOND);
 
       logger.debug(
-        `${req.method} - ${req.url} - Request by ${token.name}, ${
-          token.email
+        `${req.method} - ${req.url} - Request by ${user.name}, ${
+          user.email
         } - Token valid until - ${tokenExpiry.format()}`,
       );
-      res.locals.user = token;
+      res.locals.user = user;
       next();
     } catch (error) {
       const { name, message } = error;
@@ -51,18 +48,38 @@ const authMiddleware = (req, res, next) => {
       res.status(401).json({ error: 'Unauthorized' });
     }
   } else {
-    // There is no authorization
-    // check if it is a healthcheck endpoint they are accessing,
-    // otherwise they are denied.
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+};
 
-    switch (req.path) {
-      case '/_health':
-        next();
-        break;
-      default:
-        res.status(401).json({ error: 'Unauthorized' });
-        break;
-    }
+const hawkAuthMiddleware = async (req, res, next) => {
+  try {
+    const credentialsFunc = id => config.hawkCredentials.find(credential => credential.id === id);
+    const { credentials, artifacts } = await Hawk.server.authenticate(
+      req,
+      credentialsFunc,
+    );
+
+    res.locals.user = {
+      name: credentials.user,
+      refdbrole: credentials.role,
+    };
+
+    next();
+  } catch (e) {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+};
+
+const authMiddleware = async (req, res, next) => {
+  if (req.path === '/_health') {
+    next();
+  } else if (req.headers.authorization && req.headers.authorization.startsWith(BEARER)) {
+    jwtAuthMiddleware(req, res, next);
+  } else if (req.headers.authorization && req.headers.authorization.startsWith(HAWK)) {
+    await hawkAuthMiddleware(req, res, next);
+  } else {
+    res.status(401).json({ error: 'Unauthorized' });
   }
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       KEYCLOAK_URL: ${KEYCLOAK_URL}
       DB_REF_HOSTNAME: db_ref
       DB_REF_PORT: 5432
+      HAWK_SGMR_ACCESS_KEY_ID: sgmr_key_id
+      HAWK_SGMR_SECRET_ACCESS_KEY: sgmr_secret_access_key
     depends_on:
       - db_ref
       - refdata_flyway

--- a/docs/drone-secrets.md
+++ b/docs/drone-secrets.md
@@ -19,6 +19,8 @@
 | env_api_ref_limit_rows                      | false                                                                                                                                                              |
 | env_api_ref_url                             | api.dev.refdata.homeoffice.gov.uk, api.staging.refdata.homeoffice.gov.uk, api.refdata.homeoffice.gov.uk                                                            |
 | env_db_ref_hostname                         | copreferencedev.notprod.acp.homeoffice.gov.uk, coprefdatastaging.crckizhiyjmt.eu-west-2.rds.amazonaws.com, coprefdataprod.crckizhiyjmt.eu-west-2.rds.amazonaws.com |
+| env_hawk_sgmr_access_key_id                 | 5f9e24b4-904c-4f89-9e4b-8dc134f7bbba                                                                                                                               |
+| env_hawk_sgmr_secret_access_key             | fcabc957-810c-4184-bb12-3d228540f82e                                                                                                                               |
 | env_db_ref_reference_authenticator_password | xxx                                                                                                                                                                |
 | env_keycloak_realm                          | cop-dev, cop-staging, cop-prod                                                                                                                                     |
 | env_keycloak_url                            | sso-dev.notprod.homeoffice.gov.uk/auth, sso.digital.homeoffice.gov.uk/auth                                                                                         |

--- a/env.yaml
+++ b/env.yaml
@@ -10,6 +10,10 @@ keys:
         name
         port
         url
+  - hawk:
+      sgmr:
+        access_key_id
+        secret_access_key
   - db:
       ref:
         hostname

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -68,6 +68,10 @@ spec:
           value: "{{.DB_REF_REFERENCE_AUTHENTICATOR_USERNAME}}"
         - name: DB_REF_REFERENCE_AUTHENTICATOR_PASSWORD
           value: "{{.DB_REF_REFERENCE_AUTHENTICATOR_PASSWORD}}"
+        - name: HAWK_SGMR_ACCESS_KEY_ID
+          value: "{{.HAWK_SGMR_ACCESS_KEY_ID}}"
+        - name: HAWK_SGMR_SECRET_ACCESS_KEY
+          value: "{{.HAWK_SGMR_SECRET_ACCESS_KEY}}"
         - name: KEYCLOAK_URL
           value: "{{.KEYCLOAK_URL}}"
         - name: KEYCLOAK_PROTOCOL

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,72 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "requires": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "@hapi/hawk": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hawk/-/hawk-8.0.0.tgz",
+      "integrity": "sha512-VEvZUMfZKjXadT9XUt5543ol2DJN7cbcz0j/03wzVcuFxyjuyUaM38aHjf4jxr4feU9B2RT9JOV+H9Q4Ax72qA==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/sntp": "4.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+    },
+    "@hapi/sntp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/sntp/-/sntp-4.0.0.tgz",
+      "integrity": "sha512-yBXTlySZyPZKz0NPoxxFClKNMmVhsZq84Ir7+k93XNGLdSnY3iD0BosxflLpIbP7yr3p4T+QDPMNgOA3XccdFQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "4.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
+      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/ref-data-api#readme",
   "dependencies": {
+    "@hapi/hawk": "^8.0.0",
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Description

Create a Hawk authentication to allow service users, sGMR being the first one.

## Testing

1. Start docker `docker-compose up --build`
2. Open postman
3. Create GET request to `http://localhost:5001/v2/entities/port?mode=dataOnly&select=id,name`
4. Set authentication to `Hawk` and provide the following values (they match the env vars from docker compose)
   `Hawk Auth ID` = `sgmr_key_id`
   `Hawk Auth Key` = `sgmr_secret_access_key`
   `Algorithm` = `sha256`
5. Execute the request
6. You should see results 🥳

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
