### PR TITLE
Add filter to search entities by partial string matching

### DIFF
--- a/app/db/queryFilterDecoder.js
+++ b/app/db/queryFilterDecoder.js
@@ -245,6 +245,13 @@ function queryFilterDecodeV2({ name, queryParams }) {
         // therefore prepared statements are not allowed
         // hence adding the value in place of the index.
         placeholders = value;
+      } else if (filter === 'contains' && !isNull) {
+        // country ILIKE '%pol%'
+        filter = 'ILIKE';
+        value = `%${value}%`;
+        values.push(value);
+        placeholders = `$${index}`;
+        index += 1;
       } else {
         filter = 'IN';
         value = value.replace('(', '');

--- a/test/db/queryFilterDecoder.test.js
+++ b/test/db/queryFilterDecoder.test.js
@@ -501,5 +501,19 @@ describe('Test Database Utils', () => {
       expect(queryFilter).to.be.an('object');
       expect(queryFilter).to.deep.equal(expectedQueryObject);
     });
+
+    it('Should resolve single "contains" filtering using string value', () => {
+      const name = 'country';
+      const queryParams = { filter: ['country=contains.pol'] };
+      const expectedQueryObject = {
+        queryString: 'SELECT * FROM country WHERE country ILIKE $1',
+        values: ['%pol%'],
+      };
+
+      const queryFilter = queryFilterDecodeV2({ name, queryParams });
+
+      expect(queryFilter).to.be.an('object');
+      expect(queryFilter).to.deep.equal(expectedQueryObject);
+    });
   });
 });


### PR DESCRIPTION
## Description

Add new filter type which allows to search for entities by partial string matching.

## Testing

1. Send an get request to http://localhost:5000/v2/entities/port?mode=dataOnly&select=unlocode,name&limit=50&filter=sea=eq.true&filter=name=contains.abb
2. Check if the returned entities matches our filter (`abb`)

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
